### PR TITLE
grunt watch is back

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -424,7 +424,9 @@ module.exports = function ( grunt ) {
           '<%= vendor_files.js %>',
           '<%= html2js.app.dest %>',
           '<%= html2js.common.dest %>',
-          '<%= test_files.js %>'
+          '<%= test_files.js %>',
+          '<%= app_files.js %>',
+          '<%= app_files.jsunit %>'
         ]
       }
     },
@@ -434,7 +436,7 @@ module.exports = function ( grunt ) {
      */
     express: {
       options: {
-        output: 'Express server listening on port'
+        output: 'Express.*listening on port.*'
       },
       prod: {
         options: {
@@ -577,7 +579,7 @@ module.exports = function ( grunt ) {
        */
       express: {
         files: [ 'server/**/*.js' ],
-        task: [ 'express:unique' ],
+        tasks: [ 'express:dev' ],
         options: {
             spawn: false
         }
@@ -595,7 +597,7 @@ module.exports = function ( grunt ) {
    * before watching for changes.
    */
   grunt.renameTask( 'watch', 'delta' );
-  grunt.registerTask( 'watch', [ 'build', 'karma:unit', 'delta' ] );
+  grunt.registerTask( 'watch', [ 'build', 'karma:unit', 'express:dev', 'delta' ] );
 
   /**
    * The default task is to build and compile.
@@ -633,16 +635,24 @@ module.exports = function ( grunt ) {
   });
 
   /**
-   * A utility function to get all app JavaScript sources except for app.js.
+   * An utility function to get all app JavaScript sources except for app.js.
    */
   function filterForJS ( files ) {
     return files.filter( function ( file ) {
-      return file.match( /^((?!.*\/app\.js)(?!.*vendor)).*$/ );
+      return file.match( /^((?!.*\/app\.js)(?!.*vendor)(?!.*spec)).*$/ );
+    });
+  }
+	/*
+	 * An utility function to get just the testing files.
+	 */
+  function filterForSpecJS ( files ) {
+    return files.filter( function ( file ) {
+      return file.match( /^.*\.spec\.js.*$/ );
     });
   }
 
   /**
-   * A utility function to get all vendor JavaScript sources.
+   * An utility function to get all vendor JavaScript sources.
    */
   function filterForVendorJS ( files ) {
     return files.filter( function ( file ) {
@@ -651,7 +661,7 @@ module.exports = function ( grunt ) {
   }
 
   /*
-   * A utility function to get just app.js file (needs to be written on top of the others!)
+   * An utility function to get just app.js file (needs to be written on top of the others!)
    */
   function filterForAppJS (files) {
     return files.filter( function ( file ) {
@@ -659,8 +669,8 @@ module.exports = function ( grunt ) {
     });
   }
 
-  /**
-   * A utility function to get all app CSS sources.
+  /*
+   * An utility function to get all app CSS sources.
    */
   function filterForCSS ( files ) {
     return files.filter( function ( file ) {
@@ -713,6 +723,7 @@ module.exports = function ( grunt ) {
     var vendorjsFiles = filterForVendorJS ( this.filesSrc );
     var jsFiles = filterForJS( this.filesSrc );
     var appjsFile = filterForAppJS( this.filesSrc );
+    var specjsFiles = filterForSpecJS( this.filesSrc );
 
     grunt.file.copy( 'karma/karma-unit.tpl.js', grunt.config( 'build_dir' ) + '/karma-unit.js', { 
       process: function ( contents, path ) {
@@ -720,7 +731,8 @@ module.exports = function ( grunt ) {
           data: {
             vendorjs: vendorjsFiles,
             scripts: jsFiles,
-            appjs: appjsFile
+            appjs: appjsFile,
+            specjs: specjsFiles
           }
         });
       }

--- a/build.config.js
+++ b/build.config.js
@@ -39,7 +39,9 @@ module.exports = {
    */
   test_files: {
     js: [
-      'vendor/angular-mocks/angular-mocks.js'
+      //note: angular is loaded in vendor_files
+      'vendor/angular-mocks/angular-mocks.js',
+      'node_modules/ng-describe/dist/ng-describe.js'
     ]
   },
 

--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -18,6 +18,9 @@ module.exports = function ( karma ) {
       //compiled app JavaScript
       <% scripts.forEach( function ( file ) { %>'<%= file %>',
       <% }); %>
+      //test files
+      <% specjs.forEach( function ( file ) { %>'<%= file %>',
+      <% }); %>
       'src/**/*.coffee'
     ],
     exclude: [

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "karma-ng-scenario": "^0.1.0",
     "keygrip": "^1.0.1",
     "load-grunt-tasks": "~0.4.0",
+    "ng-describe": "^1.5.0",
     "request": "~2.27.0",
     "sha256": "^0.1.1",
     "time-grunt": "~0.2.1"


### PR DESCRIPTION
En esta entrega:

Ahora es posible correr `grunt watch` y modificar los fuentes (incluso los del server) y todo se recarga automáticamente. Los problemas que había eran:
- La task `karma:continuous` (que es la que se corre una vez previo a `delta` --que vigila los cambios, i.e., `watch` renombrada--) fallaba porque no corría ningún test. también falla cuando corre un test erróneo y eso hace que Grunt aborte las tareas restantes.
  - _Solucion_: Ninguna. Creo que está pensado para empezar con el repo limpio y pasando los tests correctamente y a partir de ahí ir trabajando hasta terminar nuevamente con los tests pasando. Los siguientes tests (al modificar los js) no causan que Grunt cierre.
- Un error en la opción `output` de Gruntfile para la task `express`.
- Otros menores. Se ven en el commit

Se agregó:
- La lista de archivos de tests a la tarea `karmaconfig` para que se carguen todos los .js necesarios.
