### PR TITLE
Neo4j garbage collector is now G1

### DIFF
--- a/bootstrap/setup
+++ b/bootstrap/setup
@@ -212,7 +212,7 @@ cd $MY_PATH
 loggerGreen "Installing service start and shutdown scripts...\n"
 
 cat $LOCATION_FILE > $BIN_DIR/neoRun
-echo "./neo4j-community-$NEO4J_VER/bin/neo4j start -server -Xmx512M -XX:+UseConcMarkSweepGC" >> $BIN_DIR/neoRun
+echo "./neo4j-community-$NEO4J_VER/bin/neo4j start -server -Xmx512M -XX:+UseG1GC" >> $BIN_DIR/neoRun
 chmod +x $BIN_DIR/neoRun
 
 cat $LOCATION_FILE > $BIN_DIR/neoStop


### PR DESCRIPTION
Desde la wiki de performance de Neo4j

> Tip
> 
> The recommended garbage collector to use when running Neo4j in production is the G1 garbage
> collector. G1 is turned on by default in server deployments. For embedded deployments, it can be
> turned on by supplying -XX:+UseG1GC as a JVM parameter.
