### PR TITLE
Deleted checkAdminCookie

### DIFF
--- a/server/routes/_users.js
+++ b/server/routes/_users.js
@@ -88,6 +88,7 @@ User.getProfile = function(idNEO,public,callback){
                 delete profile.password;
                 delete profile.salt;
                 delete profile.c;
+                delete profile.lang;
                 console.log(profile);
                 return callback(null, profile);
             }else{

--- a/server/routes/secur.js
+++ b/server/routes/secur.js
@@ -98,13 +98,18 @@ exports.extractCookieData = function (req, res, next) {
 
     var cook = new cookies(req, res, keys);
     var idCookie = cook.get('LinkedEnibId');
+    var langCookie = cook.get('LinkedEnibiLang');
 
     if (idCookie) {
-
         req.id = parseInt(idCookie);
     }
     else {
         console.log('Cookies Errors');
+    }
+    if (langCookie) {
+      req.lang = langCookie;
+    }else{
+      req.lang = 'es';
     }
 
     return next();

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -546,17 +546,26 @@ exports.login = function (req, res, next) {
             if (!secur.loggedIn(req, res)) {
                 var cook = new cookies(req, res, secur.cookKeys);
                 cook.set('LinkedEnibId', results.idNEO, {signed: true, maxAge: 9000000});
+                cook.set('LinkedEnibLang', results.lang, {signed: true, maxAge: 9000000});
                 console.log(results['idNEO']);
-                res.status(200).send({idNEO: results['idNEO'], lang: results.lang});
-                return;
+                secur.isAdmin(results.idNEO,function(is){
+                  if(is){
+                    res.status(200).send({idNEO: results['idNEO'], lang: results.lang, admin: true});
+                    return;
+                  }else{
+                    res.status(200).send({idNEO: results['idNEO'], lang: results.lang, admin: false});
+                    return;
+                  }
+                });
             }
             else {
                 res.status(401).send('Another user already logged in');
                 return;
             }
+        }else{
+          res.status(401).send('Wrong email or password');
+          return;
         }
-        res.status(401).send('Wrong email or password');
-        return;
     });
 };
 
@@ -648,7 +657,13 @@ exports.changeProperty = function (req, res, next) {
             console.log(err);
             res.sendStatus(500);
         }else{
+          if(tmp.field === 'lang'){
+            var cook = new cookies(req, res, secur.cookKeys);
+            cook.set('LinkedEnibLang', tmp.value, {signed: true, maxAge: 9000000, overwrite: true});
             res.sendStatus(200);
+          }else{
+            res.sendStatus(200);
+          }
         }
     });
 };

--- a/server/server.js
+++ b/server/server.js
@@ -121,19 +121,11 @@ app.post('/edtnewact', edt.newActivity);
 app.get('/checkCookie', secur.extractCookieData, function (req, res) {
 
     if (req.id) {
-        res.status(200).send({idNEO: req.id, lang: req.lang});
-    } else {
-        res.sendStatus(500);
-    }
-});
-app.get('/checkAdminCookie', secur.extractCookieData, function (req, res) {
-
-    if (req.id) {
         secur.isAdmin(req.id, function (is) {
             if (is)
-                res.status(200).send({idNEO: req.id, lang: req.lang});
+                res.status(200).send({idNEO: req.id, lang: req.lang, admin: true});
             else
-                res.sendStatus(500);
+                res.status(200).send({idNEO: req.id, lang: req.lang, admin: false});
         });
     } else {
         res.sendStatus(500);

--- a/src/app/session/session.factory.js
+++ b/src/app/session/session.factory.js
@@ -84,16 +84,6 @@
 						}
           }
 				};
-				var checkAdminCookie = function(){
-          $http({method:'GET', url:'/checkAdminCookie'})
-          .success(function(){
-              setAdmin(true);
-              $rootScope.$broadcast('gotAdmin');
-          })
-          .error(function(){
-              setAdmin(false);
-          });
-				};
 
 				/*
 				 * Pubilc API
@@ -114,9 +104,15 @@
             .success(function(data){
               if (data && data.idNEO){
                 log('in', data.idNEO, null);
-                checkAdminCookie();
               }else{
                 log('in', null, 'The server returned no ID');
+              }
+              if(data && data.admin){
+                setAdmin(true);
+                $rootScope.$broadcast('gotAdmin');
+              }
+              if(data && data.lang){
+                setLang(data.lang);
               }
             })
             .error(function(err){
@@ -127,10 +123,13 @@
             $http({method:'GET', url:'/checkCookie'})
             .success(function (data){
               log('in',data.idNEO);
-              checkAdminCookie();
+              if(data.admin){
+                setAdmin(true);
+                $rootScope.$broadcast('gotAdmin');
+              }
+              setLang(data.lang);
             })
             .error(function(){
-							//
             });
 					},
 					updateContacts: function(){
@@ -163,7 +162,6 @@
             $http({method:'GET', url:'/profile/'+api.getID()})
             .success(function (_profile){
 								setProfile(_profile);
-								setLang(_profile.lang);
                 return;
             })
             .error(function(){

--- a/src/app/session/session.factory.spec.js
+++ b/src/app/session/session.factory.spec.js
@@ -57,7 +57,7 @@
 				});
 
 				it('Should fire the correct event upon correct login',function(){
-					deps.$httpBackend.expectPOST('/login').respond(200, { idNEO: 13});
+					deps.$httpBackend.expectPOST('/login').respond(200, { idNEO: 13, lang: 'ar', admin:false});
 					deps.session.login();
 
 					deps.http.flush();
@@ -88,7 +88,7 @@
 				});
 
 				it('Should fire the correct event upon correct logout',function(){
-					deps.$httpBackend.expectPOST('/login').respond(200, { idNEO: 13});
+					deps.$httpBackend.expectPOST('/login').respond(200, { idNEO: 13, lang: 'ar', admin: false});
 					deps.session.login();
 
 					deps.http.flush();
@@ -193,41 +193,66 @@
 				beforeEach(function(){
 					deps.$httpBackend.whenGET(/.*/).respond(500, 'Error');
 					deps.$httpBackend.whenPOST(/.*/).respond(500, 'Error');
-					deps.$httpBackend.expectGET(/.*\/translation\/[a-z]+$/).respond(200, { translation: {test: 'default'}});
+					deps.$httpBackend.expectGET(/\/translation\/[a-z]+$/).respond(200, { translation: {test: 'default'}});
 					deps.http.flush();
 					spyOn(deps.$rootScope,'$broadcast');
 				});
 
 				it('Verify session state after succesful login',function(){
-					deps.$httpBackend.expectPOST('/login').respond(200, {idNEO: 13});
-					deps.$httpBackend.expectGET(/.*\/profile\/[0-9]+/).respond(200, { test: 'hola', lang: 'ar'});
+					deps.$httpBackend.expectPOST('/login').respond(200, {idNEO: 13, lang:'ar', admin:false});
+					deps.$httpBackend.expectGET(/\/profile\/[0-9]+/).respond(200, { test: 'hola'});
 					deps.$httpBackend.expectGET('/contacts').respond(200, { test: 'bonjour'});
 					deps.$httpBackend.expectGET('/subscriptions').respond(200, { test: 'hello'});
-					deps.$httpBackend.expectGET(/.*\/translation\/[a-z]+$/).respond(200, { translation: { test: 'yay'}});
+					deps.$httpBackend.expectGET(/\/translation\/[a-z]+$/).respond(200, { translation: { test: 'yay'}});
 					deps.session.login({});
 
 					deps.http.flush();
 
 					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('login',null);
-					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('gotProfile',{ test: 'hola', lang: 'ar'});
+					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('gotProfile',{ test: 'hola'});
 					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('gotContacts',{ test: 'bonjour'});
 					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('gotSubscriptions',{ test: 'hello'});
 
 					expect(deps.session.isLoggedIn()).toBe(true);
 					expect(deps.session.isAdmin()).toBe(false);
 					expect(deps.session.getID()).toEqual(13);
-					expect(deps.session.getProfile()).toEqual({ test: 'hola', lang: 'ar'});
+					expect(deps.session.getProfile()).toEqual({ test: 'hola'});
 					expect(deps.session.getContacts()).toEqual({ test: 'bonjour'});
 					expect(deps.session.getSubscriptions()).toEqual({ test: 'hello'});
 					expect(deps.session.getTranslation()).toEqual({ test: 'yay'});
 				});
 
-				it('Verify session state after succesful logout',function(){
-					deps.$httpBackend.expectPOST('/login').respond(200, {idNEO: 13});
-					deps.$httpBackend.expectGET(/.*\/profile\/[0-9]+/).respond(200, { test: 'hola', lang: 'ar'});
+				it('Verify session state after succesful login - 2',function(){
+					deps.$httpBackend.expectPOST('/login').respond(200, {idNEO: 13, lang:'ar', admin:true});
+					deps.$httpBackend.expectGET(/\/profile\/[0-9]+/).respond(200, { test: 'hola'});
 					deps.$httpBackend.expectGET('/contacts').respond(200, { test: 'bonjour'});
 					deps.$httpBackend.expectGET('/subscriptions').respond(200, { test: 'hello'});
-					deps.$httpBackend.expectGET(/.*\/translation\/[a-z]+$/).respond(200, { translation: { test: 'yay'}});
+					deps.$httpBackend.expectGET(/\/translation\/[a-z]+$/).respond(200, { translation: { test: 'yay'}});
+					deps.session.login({});
+
+					deps.http.flush();
+
+					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('login',null);
+					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('gotProfile',{ test: 'hola'});
+					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('gotContacts',{ test: 'bonjour'});
+					expect(deps.$rootScope.$broadcast).toHaveBeenCalledWith('gotSubscriptions',{ test: 'hello'});
+
+					expect(deps.session.isLoggedIn()).toBe(true);
+					expect(deps.session.isAdmin()).toBe(true);
+					expect(deps.session.getID()).toEqual(13);
+					expect(deps.session.getProfile()).toEqual({ test: 'hola'});
+					expect(deps.session.getContacts()).toEqual({ test: 'bonjour'});
+					expect(deps.session.getSubscriptions()).toEqual({ test: 'hello'});
+					expect(deps.session.getTranslation()).toEqual({ test: 'yay'});
+				});
+
+
+				it('Verify session state after succesful logout',function(){
+					deps.$httpBackend.expectPOST('/login').respond(200, {idNEO: 13, lang: 'ar', admin:false});
+					deps.$httpBackend.expectGET(/\/profile\/[0-9]+/).respond(200, { test: 'hola'});
+					deps.$httpBackend.expectGET('/contacts').respond(200, { test: 'bonjour'});
+					deps.$httpBackend.expectGET('/subscriptions').respond(200, { test: 'hello'});
+					deps.$httpBackend.expectGET(/\/translation\/[a-z]+$/).respond(200, { translation: { test: 'yay'}});
 					deps.session.login({});
 
 					deps.http.flush();
@@ -248,7 +273,7 @@
 				});
 
 				it('Should try to change the user language when language is selected',function(){
-					deps.$httpBackend.expectPOST('/login').respond(200, { idNEO: 13});
+					deps.$httpBackend.expectPOST('/login').respond(200, { idNEO: 13, lang: 'ar', admin: false});
 					deps.session.login({});
 
 					deps.http.flush();
@@ -323,8 +348,7 @@
 				});
 
 				it('Should set the admin flag correctly',function(){
-					deps.$httpBackend.expectGET('/checkCookie').respond(200, { idNEO: 13});
-					deps.$httpBackend.expectGET('/checkAdminCookie').respond(200, { idNEO: 13});
+					deps.$httpBackend.expectGET('/checkCookie').respond(200, { idNEO: 13, lang: 'ar', admin:true});
 					deps.session.checkCookie();
 
 					deps.http.flush();


### PR DESCRIPTION
Se eliminó la verificación extra de admin y se hace en el server con /checkCookie.

Aproveché para poner Una cookie 🍪  de idioma.

Van a haber conflictos en un unit test, es mejor mergear primero #127 y dsp arreglo lo que aparezca.

Fixes #69 
