### PR TITLE
Fixes #120. Week navigation is fixed. Bug fixes.

### DIFF
--- a/server/routes/_admin.js
+++ b/server/routes/_admin.js
@@ -26,7 +26,7 @@ exports.getAdminNodes = function(idNEO, callback){
 				return callback(null,'Unauthorized');
 			}else{
 				results.forEach(function(res){
-					res.nodeData = res.nodeData._data.data;
+					res.nodeData = res.nodeData.properties;
 					res.label = res.label[0];
 				});
 				return callback(null, results);
@@ -54,7 +54,7 @@ exports.getNodeRelTypes = function(memberof, callback){
 				var parts = [];
 				var rels = [];
 				results.forEach(function(res){
-					res = res.nodeData._data.data;
+					res = res.nodeData.properties;
 					if(res.type === 'User'){
 						//Handle relationships
 						rels.push(res);

--- a/server/routes/_edt.js
+++ b/server/routes/_edt.js
@@ -24,8 +24,8 @@ exports.getTimes = function(timeData, callback){
 			}else{
 				var times = [];
 				res.forEach(function(time){
-					time.time._data.data['idNEO']=time.idNEO;
-					times.push(time.time._data.data);
+					time.time.properties['idNEO']=time.idNEO;
+					times.push(time.time.properties);
 				});
 				return callback(null, times);
 			}
@@ -51,8 +51,8 @@ exports.getActivityTypes = function(parent, callback){
 		} else {
 		  var activityTypes = [];
 		  res.forEach(function(type){
-			type.activityType._data.data['idNEO']=type.idNEO;
-			activityTypes.push(type.activityType._data.data);
+			type.activityType.properties['idNEO']=type.idNEO;
+			activityTypes.push(type.activityType.properties);
 		  });
 		  return callback(null, activityTypes);
 		}

--- a/src/app/edt/edt.tpl.html
+++ b/src/app/edt/edt.tpl.html
@@ -39,7 +39,7 @@
         </div>
 
         <div class="edtSearchGroup" ng-show="session.isLoggedIn()">
-            <button class="edtSearchBtn" id="newActivityBtn" ng-click="newActCollapse = !newActCollapse">
+            <button class="edtSearchBtn" id="newActivityBtn" ng-click="toggleNewActForm()">
                 <i id="newActivityIcon" class="fa fa-fw" ng-class="{'fa-plus': newActCollapse, 'fa-calendar': !newActCollapse}"></i>
             </button>
         </div>    


### PR DESCRIPTION
- La navegación es ilimitada.
  - Si nos pasamos de la Semana 1, pasamos a la última del año anterior.
  - Si nos pasamos de la Semana N, pasamos a la primera del año siguiente.
  - En ambos casos se carga el número de semanas del año que se está navegando en el dropdown (que hay que corregir según #121)
- Eliminé un $timeout. Ahora, en teoría y si bien le falta trabajo al controlador del edt, no se deberían generar errores por los tiempos de carga del DOM principal. 
- Queda un $timeout cuando se adosa el calendario (datepicker) a los inputs de fechas. Esto es porque si lo hacemos rápido, no se termina de cargar el DOM del form de nueva actividad.
  - **Solución**: Buscar otra biblioteca que tenga un datepicker (se está usando jquery-ui). Realmente creo que sería bueno sacarlo porque me parece que es lo único que se usa de esa biblioteca.
