### PR TITLE
Calendars can now be merged! Fixes #16

### DIFF
--- a/server/routes/_edt.js
+++ b/server/routes/_edt.js
@@ -134,3 +134,29 @@ exports.newActivity = function(acts, callback){
 		return callback(err);
 	}
 };
+
+exports.mergeCalendar = function(myID, subID, mergeCal, callback){
+
+    var params = {
+        myID: myID,
+        subID: subID,
+        mergeCal: mergeCal
+    };
+
+    var query = [
+        'MATCH (u)-[r]->(i) WHERE ID(u)={myID}',
+        'AND ID(i)={subID}',
+        'SET r.mergeCal={mergeCal}'
+    ].join('\n');
+    try {
+        db.cypher({query: query, params:params}, function (err, results) {
+            if(err){
+                return callback(err);
+            }else{
+                return callback(null);
+            }
+        });
+    }catch(err){
+        return callback(err);
+    }
+};

--- a/server/routes/_edt.js
+++ b/server/routes/_edt.js
@@ -12,7 +12,7 @@ exports.getTimes = function(timeData, callback){
     
     var query = [
         'MATCH (a:ACTIVITY)',
-        'WHERE (a.whatId='+timeData.whatId+' OR a.whoId='+timeData.whoId+')',
+        'WHERE (a.whatId='+timeData.id+' OR a.whoId='+timeData.id+')',
         'AND a.week='+timeData.week+' AND a.year='+timeData.year,
         'RETURN a AS time, ID(a) AS idNEO'
     ].join('\n');

--- a/server/routes/_users.js
+++ b/server/routes/_users.js
@@ -350,8 +350,8 @@ User.isFriend = function (id, friend, callback) {
 User.getSubscriptions = function (idNEO, callback){
     
     var query = [
-        'MATCH (n:User)-[:SUBSCRIBED]->(s) WHERE ID(n)='+idNEO,
-        'RETURN distinct s, ID(s) AS idNEO'
+        'MATCH (n:User)-[r:SUBSCRIBED]->(s) WHERE ID(n)='+idNEO,
+        'RETURN distinct s, ID(s) AS idNEO, r.mergeCal AS mergeCal'
     ].join('\n');
     
     try{
@@ -363,6 +363,7 @@ User.getSubscriptions = function (idNEO, callback){
 			results.forEach(function(el){
 				var temp = el.s.properties;
 				temp['idNEO']=el.idNEO;
+                temp['mergeCal']=el.mergeCal;
 				subsc.push(temp);
 			});
 			return callback(null,subsc);
@@ -488,12 +489,13 @@ User.subscribe = function(idNEO, instId, callback){
     
     var params = {
         instID: instId,
-        usrID: idNEO
+        usrID: idNEO,
+        mergeCal: true
     };
   
     var query = [
     'MATCH (u),(i) WHERE ID(u)={usrID} AND ID(i)={instID}',
-    'MERGE (u)-[:SUBSCRIBED]->(i)'
+    'MERGE (u)-[:SUBSCRIBED {mergeCal: {mergeCal}}]->(i)'
     ].join('\n');
     
     try{

--- a/server/routes/edt.js
+++ b/server/routes/edt.js
@@ -75,8 +75,8 @@ exports.getEdtConfig = function(req, res, next){
  */
 exports.getTimesIcal = function(req, res, next){
     
-    if( !req.query.whatId || !req.query.whoId || 
-        !req.query.week || !req.query.year || !req.query.whatName)
+    if( !req.query.id || !req.query.week
+        || !req.query.year || !req.query.whatName)
     {
         res.status(401).send('Missing information');
         return;
@@ -86,8 +86,7 @@ exports.getTimesIcal = function(req, res, next){
         //TODO: Extender a array de whats
         whatName: req.query.whatName,
         //whoName: req.query.whoName,
-        whatId: req.query.whatId,
-        whoId: req.query.whoId,
+        id: req.query.id,
         week: req.query.week,
         year: req.query.year,
     };
@@ -160,8 +159,7 @@ exports.getTimesIcal = function(req, res, next){
 exports.getTimes = function(req, res, next){
   
     var timeData = {
-        whatId: req.query.whatId,
-        whoId: req.query.whoId,
+        id: req.query.id,
         week: req.query.week,
         year: req.query.year,
     };

--- a/server/routes/edt.js
+++ b/server/routes/edt.js
@@ -243,3 +243,29 @@ exports.newActivity = function (req, res, next) {
         }
     });
 };
+
+/**
+ * TODO : Comment on functionality
+ */
+exports.mergeCalendar = function(req, res, next) {
+
+    if(!req.id){
+        res.status(401).send('Unauthorized');
+        return;
+    }
+    if(!req.body.idNEO || typeof(req.body.mergeCal) !== "boolean"){
+        res.status(400).send('Missing Parameters');
+        return;
+    }
+
+    Edt.mergeCalendar(req.id, req.body.idNEO, req.body.mergeCal, function(err){
+        if(err){
+            console.log(err);
+            res.status(500).send('Internal Server Error');
+            return;
+        }else{
+            res.status(200).send('Ok');
+            return;
+        }
+    });
+};

--- a/server/routes/edt.js
+++ b/server/routes/edt.js
@@ -253,8 +253,12 @@ exports.mergeCalendar = function(req, res, next) {
         res.status(401).send('Unauthorized');
         return;
     }
-    if(!req.body.idNEO || typeof(req.body.mergeCal) !== "boolean"){
+    if( typeof(req.body.idNEO) === 'undefined' || typeof(req.body.mergeCal) === 'undefined'){
         res.status(400).send('Missing Parameters');
+        return;
+    }
+    if( !Number.isInteger(req.body.idNEO) || typeof(req.body.mergeCal) !== 'boolean'){
+        res.status(400).send('Incorrect Data Type');
         return;
     }
 

--- a/server/routes/edt.js
+++ b/server/routes/edt.js
@@ -158,8 +158,13 @@ exports.getTimesIcal = function(req, res, next){
  */
 exports.getTimes = function(req, res, next){
   
+    if(!Array.isArray(req.query.ids)){
+        req.query.ids = req.query.ids?[req.query.ids]:[];
+    }
     var timeData = {
-        id: req.query.id,
+        me: req.query.me==="true",
+        myID: req.id,
+        ids: req.query.ids,
         week: req.query.week,
         year: req.query.year,
     };

--- a/server/server.js
+++ b/server/server.js
@@ -96,7 +96,7 @@ if('development' == app.get('env')){
 
 /****************************    EDT REQUESTS   *******************************/
 app.get('/acttypes', secur.extractCookieData, edt.getActivityTypes);
-app.get('/times', edt.getTimes);
+app.get('/times', secur.extractCookieData, edt.getTimes);
 app.get('/edtconfig', edt.getEdtConfig);
 app.get('/edtplaces', edt.getPlaces);
 app.get('/getTimesIcal', edt.getTimesIcal);

--- a/server/server.js
+++ b/server/server.js
@@ -102,6 +102,7 @@ app.get('/edtplaces', edt.getPlaces);
 app.get('/getTimesIcal', edt.getTimesIcal);
 app.get('/subscriptions', secur.extractCookieData, users.getSubscriptions);
 app.post('/edtnewact', secur.extractCookieData, edt.newActivity);
+app.post('/edtmergecal', secur.extractCookieData, edt.mergeCalendar);
 /******************************************************************************/
 
 /****************************   COOKIES REQUESTS   ****************************/

--- a/server/specs/edt.spec.js
+++ b/server/specs/edt.spec.js
@@ -118,5 +118,101 @@
                   });
             });
         });
+
+        describe('Merge Calendars', function(){
+
+            it('should return 401 if not logged in', function(done){
+
+                request(server)
+                  .post('/edtmergecal')
+                  .expect(401, 'Unauthorized')
+                  .end(function(err, res){
+                      if(err){
+                          return done.fail(err);
+                      }
+                      done();
+                  });
+            });
+
+            it('should return 400 if some data is missing', function(done){
+                var dataWrong1 = {idNEO: 58};
+
+                request(server)
+                  .post('/edtmergecal')
+                  .send(dataWrong1)
+                  .set('Cookie', ['LinkedEnibId=3'])
+                  .expect(400, 'Missing Parameters')
+                  .end(function(err, res){
+                      if(err){
+                          return done.fail(err);
+                      }
+                      done();
+                  });
+            });
+
+            it('should return 400 if some data is missing - 2', function(done){
+                var dataWrong2 = {mergeCal: true};
+
+                request(server)
+                  .post('/edtmergecal')
+                  .send(dataWrong2)
+                  .set('Cookie', ['LinkedEnibId=3'])
+                  .expect(400, 'Missing Parameters')
+                  .end(function(err, res){
+                      if(err){
+                          return done.fail(err);
+                      }
+                      done();
+                  });
+            });
+
+            it('should return 200 if data is ok', function(done){
+                var dataCorrect = {idNEO: 58, mergeCal: true};
+
+                request(server)
+                  .post('/edtmergecal')
+                  .send(dataCorrect)
+                  .set('Cookie', ['LinkedEnibId=3'])
+                  .expect(200, 'Ok')
+                  .end(function(err, res){
+                      if(err){
+                          return done.fail(err);
+                      }
+                      done();
+                  });
+            });
+
+            it('should return 400 if type of data is incorrect', function(done){
+                var dataWrong1 = {idNEO: "58", mergeCal: true};
+
+                request(server)
+                  .post('/edtmergecal')
+                  .send(dataWrong1)
+                  .set('Cookie', ['LinkedEnibId=3'])
+                  .expect(400, 'Incorrect Data Type')
+                  .end(function(err, res){
+                      if(err){
+                          done.fail(err);
+                      }
+                      done();
+                  });
+            });
+
+            it('should return 400 if type of data is incorrect', function(done){
+                var dataWrong2 = {idNEO: 58, mergeCal: "asd"};
+
+                request(server)
+                  .post('/edtmergecal')
+                  .send(dataWrong2)
+                  .set('Cookie', ['LinkedEnibId=3'])
+                  .expect(400, 'Incorrect Data Type')
+                  .end(function(err, res){
+                      if(err){
+                          done.fail(err);
+                      }
+                      done();
+                  });
+            });
+        });
     });
 })();

--- a/server/specs/mocks/_edt.mock.js
+++ b/server/specs/mocks/_edt.mock.js
@@ -14,5 +14,9 @@
         return callback(null, []);
     };
 
+    exports.mergeCalendar = function(myID, subID, mergeCal, callback){
+        return callback(null);
+    };
+
     exports.isMock = true;
 })();

--- a/src/app/edt/edt.factory.js
+++ b/src/app/edt/edt.factory.js
@@ -13,9 +13,9 @@
     };
 
     var api = {
-      getTimes: function(whatId, whoId, week, year, next){
+      getTimes: function(id, week, year, next){
         $http({ method:'GET', url:'/times',
-                params:{whatId:whatId, whoId:whoId, week:week, year:year}})
+                params:{id:id, week:week, year:year}})
         .success(function(data){
           return next(null,data.times);
         })

--- a/src/app/edt/edt.factory.js
+++ b/src/app/edt/edt.factory.js
@@ -77,6 +77,15 @@
       },
       getConfig: function(){
         return angular.copy(config);
+      },
+      mergeCalendar: function(idNEO, mergeCal, next){
+          $http({method:'POST', url:'/edtmergecal', data:{idNEO:idNEO, mergeCal:mergeCal}})
+          .success(function(){
+              return next(null);
+          })
+          .error(function(){
+              return next('Error Updating Merge Attribute');
+          });
       }
     };
 

--- a/src/app/edt/edt.factory.js
+++ b/src/app/edt/edt.factory.js
@@ -13,9 +13,9 @@
     };
 
     var api = {
-      getTimes: function(id, week, year, next){
+      getTimes: function(ids, week, year, me, next){
         $http({ method:'GET', url:'/times',
-                params:{id:id, week:week, year:year}})
+                params:{ids:ids, week:week, year:year, me:me}})
         .success(function(data){
           return next(null,data.times);
         })

--- a/src/app/edt/edt.js
+++ b/src/app/edt/edt.js
@@ -23,15 +23,12 @@
         //Required. If not present produce errors.
         $scope.dummyWhenFrom = [];
         $scope.dummyWhenTo = [];
-        $scope.whatIdToSearch = 0;
-        $scope.whoIdToSearch = 0;
+        $scope.idToSearch = 0;
         
         if($stateParams.id){
-            $scope.whatIdToSearch = $stateParams.id;
-            $scope.whoIdToSearch = $stateParams.id;
+            $scope.idToSearch = $stateParams.id;
         }else{
-            $scope.whatIdToSearch = 0;
-            $scope.whoIdToSearch = 0;
+            $scope.idToSearch = 0;
         }
 
         $scope.newAct = {
@@ -274,8 +271,7 @@
         };
 
         $scope.selectFav = function(fav){
-            $scope.whoIdToSearch = 0;
-            $scope.whatIdToSearch = fav.idNEO;
+            $scope.idToSearch = fav.idNEO;
             
             $scope.edtGetTimes();
         };
@@ -327,8 +323,7 @@
             $scope.setDates($scope.thisWeek);
             $scope.newActCollapse = true;
 
-            $scope.whoIdToSearch = session.getID();
-            $scope.whatIdToSearch = 0;
+            $scope.idToSearch = session.getID();
 
             $scope.edtGetTimes();
 
@@ -548,8 +543,7 @@
          */
         $scope.edtGetTimes = function () {
 
-            edt.getTimes(   $scope.whatIdToSearch, 
-                            $scope.whoIdToSearch, 
+            edt.getTimes(   $scope.idToSearch,
                             $scope.searchWeek, 
                             $scope.thisYear, 
                             function (err, times) {
@@ -785,14 +779,13 @@
             $scope.newAct.whoName = session.getProfile().firstName[0] + '. ' + session.getProfile().lastName;
 
             if($stateParams.id){
-                $scope.whatIdToSearch = $stateParams.id;
-                $scope.whoIdToSearch = $stateParams.id;
+                $scope.idToSearch = $stateParams.id;
             }else{
-                $scope.whatIdToSearch = 0;
+                $scope.idToSearch = 0;
                 if(session.isLoggedIn()){
-                    $scope.whoIdToSearch = session.getID();
+                    $scope.idToSearch = session.getID();
                 }else{
-                    $scope.whoIdToSearch = 0;
+                    $scope.idToSearch = 0;
                 }
             }
 
@@ -824,9 +817,9 @@
         $scope.$on('login', function () {
             $scope.newAct.whoId = session.getID();
             if($stateParams.id){
-                $scope.whoIdToSearch = $stateParams.id;
+                $scope.idToSearch = $stateParams.id;
             }else{
-                $scope.whoIdToSearch = session.getID();
+                $scope.idToSearch = session.getID();
             }
         });
 
@@ -851,9 +844,9 @@
         if (session.isLoggedIn()) {
             $scope.newAct.whoId = session.getID();
             if($stateParams.id){
-                $scope.whoIdToSearch = $stateParams.id;
+                $scope.idToSearch = $stateParams.id;
             }else{
-                $scope.whoIdToSearch = session.getID();
+                $scope.idToSearch = session.getID();
             }
         }
 

--- a/src/app/edt/edt.js
+++ b/src/app/edt/edt.js
@@ -17,7 +17,7 @@
           }
         });
       }])
-      .controller('EdtCtrl', function ($scope, $stateParams, edt, session, $timeout, $http, $location) {
+      .controller('EdtCtrl', function ($scope, $stateParams, edt, session, $timeout, $http, $location, users) {
 
         $scope.partSearchResults = [];
         //Required. If not present produce errors.
@@ -559,6 +559,16 @@
                     $scope.times = times;
                     $scope.clearplot();
                     $scope.replot();
+                }
+            });
+        };
+
+        $scope.toggleMergeCal = function(sub, e){
+
+            e.stopPropagation();
+            edt.mergeCalendar(sub.idNEO, !sub.mergeCal, function(err){
+                if(err === null){
+                    session.updateSubscriptions();
                 }
             });
         };

--- a/src/app/edt/edt.tpl.html
+++ b/src/app/edt/edt.tpl.html
@@ -9,7 +9,10 @@
                 </button>
                 <ul class="dropdown-menu scrollable-menu edt-search-dropdown" role="menu">
                     <li role="presentation" ng-repeat="sub in subscriptions">
-                        <a role="menuitem" tabindex="-1" ng-click="selectFav(sub)">{{sub.name}}</a>
+                      <i ng-class="{'fa fa-check-square-o fa-2x': sub.mergeCal === true, 'fa fa-square-o fa-2x': sub.mergeCal === false}"
+                         ng-click="toggleMergeCal(sub, $event)" style="color:#65B8E2;" >
+                      </i>
+                        <span role="menuitem" tabindex="-1" ng-click="selectFav(sub)">{{sub.name}}</span>
                     </li>
                 </ul>
             </div>

--- a/src/app/edt/edt.tpl.html
+++ b/src/app/edt/edt.tpl.html
@@ -9,8 +9,9 @@
                 </button>
                 <ul class="dropdown-menu scrollable-menu edt-search-dropdown" role="menu">
                     <li role="presentation" ng-repeat="sub in subscriptions">
-                      <i ng-class="{'fa fa-check-square-o fa-2x': sub.mergeCal === true, 'fa fa-square-o fa-2x': sub.mergeCal === false}"
-                         ng-click="toggleMergeCal(sub, $event)" style="color:#65B8E2;" >
+                      <i class="favCheckbox"
+                         ng-class="{'fa fa-check-square-o fa-2x': sub.mergeCal === true, 'fa fa-square-o fa-2x': sub.mergeCal === false}"
+                         ng-click="toggleMergeCal(sub, $event)" >
                       </i>
                         <span role="menuitem" tabindex="-1" ng-click="selectFav(sub)">{{sub.name}}</span>
                     </li>

--- a/src/sass/checkbox.scss
+++ b/src/sass/checkbox.scss
@@ -64,3 +64,13 @@
 [type="checkbox"]:not(:checked):focus + label:before {
   border: 1px dotted blue;
 }
+
+.favCheckbox {
+  color: black;
+  padding-left: 10px;
+  font-size: 1.2em;
+}
+
+#edtSearchSelect > ul > li {
+	cursor: pointer;
+}


### PR DESCRIPTION
- El dropdown de favoritos ahora tiene checkboxes que permiten fusionar diferentes calendarios.
- Los links a los calendarios de los favoritos (individuales) siguen disponibles. Si clickeamos sobre el nombre, accedemos a ese en particular.
- Si clickeamos en los checkboxes (que son iconos), vamos eligiendo qué calendarios queremos fusionar por defecto, y esto se guarda en la BDD.
- La propiedad verificada es `mergeCal` en la relación de `SUBSCRIBED`
- Ahora cuando elegimos qué buscar desde dentro de nuestro calendario, no existen variables con las que se hagan las peticiones (antes existia `whatIdToSearch` por ejemplo). Ahora se busca lo que esté como parámetro de la página `/edt/ID`. Si es nuestro ID, se buscan tmb los favoritos que están fusionados. Si es un ID diferente al nuestro, buscamos sólo ese ID.
- Esto hace que se cumpla lo planteado en #131 sobre que _Los calendarios privados no pueden consultarse por otros usuarios_.
